### PR TITLE
Autodetect enabled regions

### DIFF
--- a/source/lambda/resource_based_policy/step_functions_lambda/scan_policy_all_services.py
+++ b/source/lambda/resource_based_policy/step_functions_lambda/scan_policy_all_services.py
@@ -1155,7 +1155,7 @@ class CodeBuildResourcePolicy:
         return scan_regions(self.event, self.scan_single_region)
 
     def scan_single_region(self, region: str) -> Iterable[model.ResourceBasedPolicyResponseModel]:
-        self.logger.info(f"Scanning Code Build Resource Policies in {region} for account {self.account_id}")
+        self.logger.info(f"Scanning Code Build Resource Policies in {region}")
         code_build_client = CodeBuild(self.account_id, region)
         code_build_project_names = code_build_client.list_projects()
         code_build_project_data: list[model.CodeBuildData] = self._get_project_data(

--- a/source/lambda/resource_based_policy/supported_configuration/supported_regions_and_services.py
+++ b/source/lambda/resource_based_policy/supported_configuration/supported_regions_and_services.py
@@ -132,7 +132,10 @@ SUPPORTED_SERVICES = [
 ]
 
 SUPPORTED_REGIONS = [
-
+    {
+        "Region": "ALL",
+        "RegionName": "Autodetect all enabled regions for each account"
+    },
     {
         "Region": "us-east-1",
         "RegionName": "US East (N. Virginia)"


### PR DESCRIPTION
*Issue #4*

*Autodetect regions:*
If user does not provide a list of regions (or selects 'ALL') we make a call to ec2.describe_regions() (new function get_regions_for_account) for each account to determine the list of all regions which are enabled for the particular account

Please, note I have not tested this code

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
