### PR TITLE
Correcting change date entry for v1.0.5 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.5] - 2023-04
+## [1.0.5] - 2023-10
 
 ### Fixed
 


### PR DESCRIPTION
*Issue #, if available:*

Not applicable

*Description of changes:*
- Fix release date for v1.0.5 as 2023-10 and not 2023-04

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
