### PR TITLE
Release/v1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.9] - 2024-08
+
+### Security
+
+- Upgrade `fast-xml-parser` to mitigate [CVE-2024-41818](https://nvd.nist.gov/vuln/detail/CVE-2024-41818)
+
+### Fixed
+
+- When scan fails for a certain S3 bucket, the solution will no longer fail the scan for all S3 buckets in the account.
+  The failed buckets will be reported as individual failures with bucket name in on the solution UI, while scan results
+  for all other buckets will be reported successfully.
+
 ## [1.0.8] - 2024-06
 
 ### Fixed

--- a/source/lambda/resource_based_policy/step_functions_lambda/scan_s3_bucket_policy.py
+++ b/source/lambda/resource_based_policy/step_functions_lambda/scan_s3_bucket_policy.py
@@ -1,5 +1,5 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
 from os import getenv
 from typing import Iterable
 
@@ -7,6 +7,7 @@ from aws_lambda_powertools import Logger
 from mypy_boto3_s3.type_defs import BucketTypeDef, GetBucketPolicyOutputTypeDef
 
 import resource_based_policy.resource_based_policy_model as model
+from assessment_runner.assessment_runner import write_task_failure
 from aws.services.s3 import S3
 from resource_based_policy.step_functions_lambda.check_policy_for_organizations_dependency import \
     CheckForOrganizationsDependency
@@ -35,26 +36,57 @@ class S3BucketPolicy:
         return [bucket.get('Name') for bucket in bucket_objects]
 
     def _get_s3_data(self, bucket_names) -> list[model.S3Data]:
-        return list(self.denormalize_to_s3_data(bucket) for bucket in bucket_names)
+        return [
+            s3_data
+            for bucket in bucket_names
+            if (s3_data := self.denormalize_to_s3_data(bucket)) is not None  # filter out buckets where api call failed
+        ]
 
-    def denormalize_to_s3_data(self, bucket_name: str) -> model.S3Data:
-        data: model.S3Data = {
-            "BucketName": bucket_name,
-            "BucketRegion": self.s3_client.get_bucket_location(bucket_name)
-        }
-        return data
+    def denormalize_to_s3_data(self, bucket_name: str) -> model.S3Data | None:
+        try:
+            bucket_location = self.s3_client.get_bucket_location(bucket_name)
+
+            data: model.S3Data = {
+                "BucketName": bucket_name,
+                "BucketRegion": bucket_location
+            }
+            return data
+        except Exception as e:
+            self.logger.error(f"Error getting bucket location for bucket {bucket_name}: {e}")
+            write_task_failure(
+                self.event['JobId'],
+                'RESOURCE_BASED_POLICIES',
+                self.event['AccountId'],
+                'n/a',
+                's3',
+                f'Unable to get_bucket_location for bucket {bucket_name}: {e}'
+            )
+
+        return None
 
     def _get_bucket_policies(self, s3_data: list[model.S3Data]) -> list[model.PolicyAnalyzerRequest]:
         bucket_names_policies = []
         for s3 in s3_data:
-            s3_client = self._get_s3_client_with_regional_endpoint_if_opt_in_region(s3)
-            policy: GetBucketPolicyOutputTypeDef = s3_client.get_bucket_policy(s3['BucketName'])
-            if policy.get('Policy'):
-                policy_object: model.PolicyAnalyzerRequest = DenormalizePolicyAnalyzerRequest().model(
-                    s3['BucketName'],
-                    policy.get('Policy')
+            bucket_name: str = s3['BucketName']
+            try:
+                s3_client = self._get_s3_client_with_regional_endpoint_if_opt_in_region(s3)
+                policy: GetBucketPolicyOutputTypeDef = s3_client.get_bucket_policy(bucket_name)
+                if policy.get('Policy'):
+                    policy_object: model.PolicyAnalyzerRequest = DenormalizePolicyAnalyzerRequest().model(
+                        bucket_name,
+                        policy.get('Policy')
+                    )
+                    bucket_names_policies.append(policy_object)
+            except Exception as e:
+                self.logger.error(f"Error getting bucket location for bucket {bucket_name}: {e}")
+                write_task_failure(
+                    self.event['JobId'],
+                    'RESOURCE_BASED_POLICIES',
+                    self.event['AccountId'],
+                    s3['BucketRegion'],
+                    's3',
+                    f'Unable to get_bucket_location for bucket {bucket_name}: {e}'
                 )
-                bucket_names_policies.append(policy_object)
         return bucket_names_policies
 
     def _get_s3_client_with_regional_endpoint_if_opt_in_region(self, s3):

--- a/source/lambda/resource_based_policy/step_functions_lambda/scan_s3_bucket_policy.py
+++ b/source/lambda/resource_based_policy/step_functions_lambda/scan_s3_bucket_policy.py
@@ -1,7 +1,7 @@
 #  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: Apache-2.0
 from os import getenv
-from typing import Iterable
+from typing import Iterable, Union
 
 from aws_lambda_powertools import Logger
 from mypy_boto3_s3.type_defs import BucketTypeDef, GetBucketPolicyOutputTypeDef
@@ -42,7 +42,7 @@ class S3BucketPolicy:
             if (s3_data := self.denormalize_to_s3_data(bucket)) is not None  # filter out buckets where api call failed
         ]
 
-    def denormalize_to_s3_data(self, bucket_name: str) -> model.S3Data | None:
+    def denormalize_to_s3_data(self, bucket_name: str) -> Union[model.S3Data, None]:
         try:
             bucket_location = self.s3_client.get_bucket_location(bucket_name)
 

--- a/source/lambda/tests/plugins/env_vars.py
+++ b/source/lambda/tests/plugins/env_vars.py
@@ -10,6 +10,7 @@ import pytest
 def pytest_load_initial_conftests():
     os.environ['LOG_LEVEL'] = 'debug'
     os.environ['AWS_REGION'] = 'us-east-1'
+    os.environ['SOLUTION_VERSION'] = "v1.0.0"
     os.environ['ORG_MANAGEMENT_ROLE_NAME'] = 'execution-role-name'
     os.environ['SPOKE_ROLE_NAME'] = 'AccountAssessment-Spoke-ExecutionRole'
     os.environ[

--- a/source/lambda/tests/test_metrics/test_solution_metrics.py
+++ b/source/lambda/tests/test_metrics/test_solution_metrics.py
@@ -79,3 +79,18 @@ def test_counts_resource_based_policies_findings():
                        'FindingsCount': '4',
                        'RegionsCount': '2',
                        'ServicesCount': '3'}
+    
+def test_if_version_is_included_in_the_metrics():
+    # ARRANGE
+    findings = [
+        resource_based_policies_create_request('s3.amazonaws.com', 'us-east-1'),
+        resource_based_policies_create_request('glacier.amazonaws.com', 'us-east-1'),
+        resource_based_policies_create_request('sns.amazonaws.com', 'us-east-2'),
+        resource_based_policies_create_request('sns.amazonaws.com', 'us-east-2'),
+    ]
+
+    # ACT
+    metrics = SolutionMetrics()._generate_metrics('RESOURCE_BASED_POLICIES', findings)
+
+    model = SolutionMetrics()._denormalize_to_metrics_model(metrics)
+    assert model.get("Version") == "v1.0.0"

--- a/source/lambda/tests/test_resource_based_policy/test_s3_policy_for_organizations_dependency.py
+++ b/source/lambda/tests/test_resource_based_policy/test_s3_policy_for_organizations_dependency.py
@@ -1,11 +1,15 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
 import json
+import os
 
 import pytest
 from aws_lambda_powertools import Logger
 from moto import mock_s3, mock_sts
 
+from assessment_runner.jobs_repository import JobsRepository
+
+os.environ['AWS_REGION'] = 'us-east-1'
 from resource_based_policy.step_functions_lambda.scan_s3_bucket_policy import S3BucketPolicy
 from tests.test_resource_based_policy.mock_data import mock_policies, event
 
@@ -27,17 +31,19 @@ def test_s3_policy_scan_no_buckets():
 @pytest.fixture
 def s3_setup(s3_client, s3_client_resource):
     # ARRANGE
+    number_of_buckets = 0
     for policy_object in mock_policies:
         if policy_object.get('MockResourceName'):
             bucket = s3_client_resource.Bucket(policy_object.get('MockResourceName'))
             bucket.create()
+            number_of_buckets += 1
             if policy_object.get('MockPolicy'):  # skip if no policy
                 s3_client.put_bucket_policy(
                     Bucket=policy_object.get('MockResourceName'),
                     Policy=json.dumps(policy_object.get('MockPolicy')))
                 logger.info(f"For S3 Bucket: {policy_object.get('MockResourceName')} "
                             f"put policy: {policy_object.get('MockPolicy')}")
-
+    yield number_of_buckets
 
 @mock_sts
 def test_s3_policy_scan(s3_setup):
@@ -56,3 +62,32 @@ def test_s3_policy_scan(s3_setup):
             'aws:ResourceOrgPaths'
         ]
 
+
+@mock_sts
+def test_s3_policy_scan_get_bucket_location_catches_error(job_history_table, s3_setup, mocker):
+    mock_get_bucket_location = mocker.patch('aws.services.s3.S3.get_bucket_location')
+    # Simulate the first and third call raising exceptions, every other call succeeding
+    mock_get_bucket_location.side_effect = [Exception("Access Denied"), "us-east-1", Exception("Not Found")] + [
+        "us-west-2"] * 100
+
+    s3_bucket_policy = S3BucketPolicy(event)
+
+    response = s3_bucket_policy.scan()
+    logger.info(response)
+
+    # Verify that get_bucket_location was called for each bucket, doesn't abort scan after the first error
+    number_of_buckets = s3_setup
+    assert mock_get_bucket_location.call_count == number_of_buckets
+
+    failed_tasks = JobsRepository().find_task_failures_by_job_id(
+        event['JobId']
+    )
+
+    # Verify that the failed tasks are stored in dynamodb, so the user knows which buckets they need to check manually
+    assert len(failed_tasks) == 2
+    expected_errors = {
+        'Unable to get_bucket_location for bucket resource_1: Access Denied',
+        'Unable to get_bucket_location for bucket resource_3: Not Found'
+    }
+    actual_errors = set(task['Error'] for task in failed_tasks)
+    assert actual_errors == expected_errors

--- a/source/lambda/tests/test_utils/test_exceptions.py
+++ b/source/lambda/tests/test_utils/test_exceptions.py
@@ -21,7 +21,7 @@ logger = Logger(service='test_exception_handler', level='INFO')
 
 
 # ARRANGE
-class TestServiceName:
+class MockService:
     def __init__(self, account_id, region):
         self.account_id = account_id
         self.region = region
@@ -57,7 +57,7 @@ class ScanTestService:
     def scan_single_region(self, region_name: str):
         test_resources_in_all_regions = []
         self.logger.info(f"Scanning Test Policies in {region_name}")
-        test_client = TestServiceName(self.account_id, region_name)
+        test_client = MockService(self.account_id, region_name)
         objects = test_client.list_regions()
         test_resources_in_all_regions.extend(objects)
         return test_resources_in_all_regions
@@ -68,7 +68,7 @@ class ScanTestService:
     def raise_single_region_not_enabled(self, region_name):
         test_resources_in_all_regions = []
         self.logger.info(f"Scanning Test Policies in {region_name}")
-        test_client = TestServiceName(self.account_id, region_name)
+        test_client = MockService(self.account_id, region_name)
         if region_name == REGION:
             test_client.raise_region_not_enabled()
         objects = test_client.list_regions()
@@ -79,7 +79,7 @@ class ScanTestService:
 
 def test_list_regions():
     # ACT
-    list_of_regions = TestServiceName(ACCOUNT_ID, REGION).list_regions()
+    list_of_regions = MockService(ACCOUNT_ID, REGION).list_regions()
 
     # ASSERT
     assert list_of_regions == [REGION]
@@ -88,7 +88,7 @@ def test_list_regions():
 def test_raise_region_not_enabled():
     # ACT
     with pytest.raises(Exception) as exc_info:
-        TestServiceName(ACCOUNT_ID, REGION).raise_region_not_enabled()
+        MockService(ACCOUNT_ID, REGION).raise_region_not_enabled()
 
     # ASSERT
     assert exc_info.value.args[0] == f"{REGION} is disabled, you must enable it before scanning resources in this " \
@@ -98,7 +98,7 @@ def test_raise_region_not_enabled():
 def test_raise_service_unavailable():
     # ACT
     with pytest.raises(Exception) as exc_info:
-        TestServiceName(ACCOUNT_ID, REGION).raise_service_unavailable()
+        MockService(ACCOUNT_ID, REGION).raise_service_unavailable()
 
     # ASSERT
     assert exc_info.value.args[0] == f"Service is not available in {REGION}."
@@ -107,7 +107,7 @@ def test_raise_service_unavailable():
 def test_raise_connection_timeout():
     # ACT
     with pytest.raises(Exception) as exc_info:
-        TestServiceName(ACCOUNT_ID, REGION).raise_connection_timeout()
+        MockService(ACCOUNT_ID, REGION).raise_connection_timeout()
 
     # ASSERT
     assert exc_info.value.args[0] == f"Service endpoint connection timed out in {REGION}"

--- a/source/lambda/utils/string_manipulation.py
+++ b/source/lambda/utils/string_manipulation.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
-from typing import List
 
 
 def sanitize(name, space_allowed=False, replace_with_character='_'):

--- a/source/lib/components/resource-based-policy-state-machine.ts
+++ b/source/lib/components/resource-based-policy-state-machine.ts
@@ -1,4 +1,4 @@
-import {Fail, JsonPath, Map, Pass, StateMachine, Succeed, TaskInput, DefinitionBody} from "aws-cdk-lib/aws-stepfunctions";
+import {Fail, JsonPath, Map, Pass, StateMachine, Succeed, TaskInput} from "aws-cdk-lib/aws-stepfunctions";
 import {LambdaInvoke} from "aws-cdk-lib/aws-stepfunctions-tasks";
 import {Construct} from "constructs";
 import * as lambda from "aws-cdk-lib/aws-lambda";
@@ -23,33 +23,25 @@ export function createStateMachine(
 
   const setJobStatusToFailed = new LambdaInvoke(scope, 'FailJob', failedJobProps).next(new Fail(scope, 'Failed'));
 
-  const definitionBody = DefinitionBody.fromChainable(
-    new Map(scope, "AccountIterator", accountIteratorProps)
-      .iterator(
-        new LambdaInvoke(
-          scope,
-          "AccountValidation",
-          accountValidationProps
-        ).next(
-          new Map(scope, "ServiceIterator", serviceIteratorProps).iterator(
-            new LambdaInvoke(
-              scope,
-              "ScanServicePerAccount",
-              scanServicePerAccountProps
-            ).next(new Pass(scope, "TaskComplete", taskCompleteProps))
+  const definition =
+    new Map(scope, 'AccountIterator', accountIteratorProps).iterator(
+      new LambdaInvoke(scope, 'AccountValidation', accountValidationProps)
+        .next(
+          new Map(scope, 'ServiceIterator', serviceIteratorProps).iterator(
+            new LambdaInvoke(scope, 'ScanServicePerAccount', scanServicePerAccountProps)
+              .next(
+                new Pass(scope, 'TaskComplete', taskCompleteProps)
+              )
           )
-        )
-      )
-      .addCatch(setJobStatusToFailed, { resultPath: "$.Error" })
-      .next(new LambdaInvoke(scope, "FinishJob", finishJobProps))
-      .next(new Succeed(scope, "Success"))
-  );
+        ))
+      .addCatch(setJobStatusToFailed, {resultPath: "$.Error"})
+      .next(new LambdaInvoke(scope, 'FinishJob', finishJobProps))
+      .next(new Succeed(scope, 'Success'));
 
-  const stateMachine = new StateMachine(scope, "ScanAllSpokeAccounts", {
-    definitionBody: definitionBody,
-    tracingEnabled: true,
+  const stateMachine = new StateMachine(scope, 'ScanAllSpokeAccounts', {
+    definition,
+    tracingEnabled: true
   });
-
   const cfnPolicy = stateMachine.role.node.findChild('DefaultPolicy')
     .node.findChild('Resource') as CfnPolicy;
   cfnPolicy && addCfnSuppressRules(cfnPolicy, [{

--- a/source/package-lock.json
+++ b/source/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "account-assessment-for-aws-organizations",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "account-assessment-for-aws-organizations",
-      "version": "1.0.7",
+      "version": "1.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.47.0-alpha.0",

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "account-assessment-for-aws-organizations",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "description": "Account Assessment for AWS Organizations (SO0217)",
   "license": "Apache-2.0",
   "author": {

--- a/source/webui/package-lock.json
+++ b/source/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "account-assessment-for-aws-organizations-webui",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "account-assessment-for-aws-organizations-webui",
-      "version": "1.0.7",
+      "version": "1.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/api": "^5.4.12",
@@ -12288,9 +12288,9 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
-      "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "funding": [
         {
           "type": "github",

--- a/source/webui/package.json
+++ b/source/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "account-assessment-for-aws-organizations-webui",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "description": "Account Assessment for AWS Organizations (SO0217)",
   "license": "Apache-2.0",
   "author": {


### PR DESCRIPTION
*Description of changes:*

## [1.0.9] - 2024-08

### Security

- Upgrade `fast-xml-parser` to mitigate [CVE-2024-41818](https://nvd.nist.gov/vuln/detail/CVE-2024-41818)

### Fixed

- When scan fails for a certain S3 bucket, the solution will no longer fail the scan for all S3 buckets in the account.
  The failed buckets will be reported as individual failures with bucket name in on the solution UI, while scan results
  for all other buckets will be reported successfully.