### PR TITLE
Update to v1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2025-12-29
+
+### Security
+
+- Updated urllib3 to v2.6.1 to mitigate [CVE-2025-66418](https://nvd.nist.gov/vuln/detail/CVE-2025-66418) and [CVE-2025-66471](https://nvd.nist.gov/vuln/detail/CVE-2025-66471)
+- Updated werkzeug to v3.1.4 to mitigate [CVE-2025-66221](https://nvd.nist.gov/vuln/detail/CVE-2025-66221)
+
 ## [1.1.5] - 2025-11-25
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -268,11 +268,9 @@ This will update your hub stack with the changed resources, but use the unchange
 
 ***
 
-## Collection of operational metrics
+## Data Collection
 
-This solution collects anonymized operational metrics to help AWS improve the quality and features of the solution. For
-more information, including how to disable this capability, please see
-the [implementation guide](https://docs.aws.amazon.com/solutions/latest/account-assessment-for-aws-organizations/reference.html).
+This solution sends operational metrics to AWS (the “Data”) about the use of this solution. We use this Data to better understand how customers use this solution and related services and products. AWS’s collection of this Data is subject to the [AWS Privacy Notice](https://aws.amazon.com/privacy/).
 
 ***
 

--- a/source/lambda/poetry.lock
+++ b/source/lambda/poetry.lock
@@ -7528,36 +7528,36 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.1"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
-    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+    {file = "urllib3-2.6.1-py3-none-any.whl", hash = "sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b"},
+    {file = "urllib3-2.6.1.tar.gz", hash = "sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "werkzeug"
-version = "3.1.3"
+version = "3.1.4"
 description = "The comprehensive WSGI web application library."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e"},
-    {file = "werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"},
+    {file = "werkzeug-3.1.4-py3-none-any.whl", hash = "sha256:2ad50fb9ed09cc3af22c54698351027ace879a0b60a3b5edf5730b2f7d876905"},
+    {file = "werkzeug-3.1.4.tar.gz", hash = "sha256:cd3cd98b1b92dc3b7b3995038826c68097dcb16f9baa63abe35f20eafeb9fe5e"},
 ]
 
 [package.dependencies]
-MarkupSafe = ">=2.1.1"
+markupsafe = ">=2.1.1"
 
 [package.extras]
 watchdog = ["watchdog (>=2.3)"]
@@ -7666,4 +7666,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "d7e76da0849874579b7a81be1b06ac8b2a403073b399625df45add7a4c907a35"
+content-hash = "d49577db4352bbfc8755e43f0f5cd2e73f3776bb981b6bc101a38cca45be18a2"

--- a/source/lambda/pyproject.toml
+++ b/source/lambda/pyproject.toml
@@ -13,7 +13,7 @@ cfnresponse = "~1.1.5"
 requests = "~2.32.4"
 pyparsing = "~3.2.3"
 pydantic = "~2.11.4"
-urllib3 = "^2.5.0"
+urllib3 = "^2.6.1"
 
 [tool.poetry.group.dev.dependencies]
 python = "^3.12"


### PR DESCRIPTION
## [1.1.6] - 2025-12-29

### Security

- Updated urllib3 to v2.6.1 to mitigate [CVE-2025-66418](https://nvd.nist.gov/vuln/detail/CVE-2025-66418) and [CVE-2025-66471](https://nvd.nist.gov/vuln/detail/CVE-2025-66471)
- Updated werkzeug to v3.1.4 to mitigate [CVE-2025-66221](https://nvd.nist.gov/vuln/detail/CVE-2025-66221)
